### PR TITLE
Ability to query and filter by if group beneficiaries meet enrollment criteria for a given status

### DIFF
--- a/social_protection/custom_filters.py
+++ b/social_protection/custom_filters.py
@@ -76,7 +76,7 @@ class BenefitPlanCustomFilterWizard(CustomFilterWizardInterface):
                 field, value_type = field.rsplit('__', 1)
             value = self.__cast_value(value, value_type)
             filter_kwargs = {f"{relation}__json_ext__{field}" if relation else f"json_ext__{field}": value}
-            query = query.filter(**filter_kwargs)
+            query = query.filter(**filter_kwargs).distinct()
         return query
 
     def __process_schema_and_build_tuple(

--- a/social_protection/gql_queries.py
+++ b/social_protection/gql_queries.py
@@ -97,13 +97,12 @@ class BeneficiaryGQLType(DjangoObjectType, JsonExtMixin):
         return self.is_eligible
 
 
-class GroupBeneficiaryGQLType(DjangoObjectType, JsonExtMixin):
-    uuid = graphene.String(source='uuid')
+class GroupBeneficiaryFilter(django_filters.FilterSet):
+    is_eligible = django_filters.BooleanFilter(method='filter_is_eligible')
 
     class Meta:
         model = GroupBeneficiary
-        interfaces = (graphene.relay.Node,)
-        filter_fields = {
+        fields = {
             "id": ["exact"],
             "status": ["exact", "iexact", "startswith", "istartswith", "contains", "icontains"],
             "date_valid_from": ["exact", "lt", "lte", "gt", "gte"],
@@ -115,7 +114,23 @@ class GroupBeneficiaryGQLType(DjangoObjectType, JsonExtMixin):
             "is_deleted": ["exact"],
             "version": ["exact"],
         }
+
+    def filter_is_eligible(self, queryset, name, value):
+        return queryset.filter(is_eligible=value)
+
+
+class GroupBeneficiaryGQLType(DjangoObjectType, JsonExtMixin):
+    uuid = graphene.String(source='uuid')
+    is_eligible = graphene.Boolean()
+
+    class Meta:
+        model = GroupBeneficiary
+        interfaces = (graphene.relay.Node,)
+        filterset_class = GroupBeneficiaryFilter
         connection_class = ExtendedConnection
+
+    def resolve_is_eligible(self, info):
+        return self.is_eligible
 
 
 class BenefitPlanDataUploadQGLType(DjangoObjectType, JsonExtMixin):

--- a/social_protection/schema.py
+++ b/social_protection/schema.py
@@ -298,7 +298,7 @@ class Query(ExportableSocialProtectionQueryMixin, graphene.ObjectType):
                     Query.object_type,
                     custom_filters,
                     query,
-                    "group",
+                    "group__groupindividual__individual",
                 )
             return query
 
@@ -323,7 +323,7 @@ class Query(ExportableSocialProtectionQueryMixin, graphene.ObjectType):
                 Query.object_type,
                 eligibility_filters,
                 query,
-                "group",
+                "group__groupindividual__individual",
             )
             eligible_group_beneficiaries = gql_optimizer.query(query_eligible, info)
             eligible_group_uuids = set(eligible_group_beneficiaries.values_list('uuid', flat=True))

--- a/social_protection/schema.py
+++ b/social_protection/schema.py
@@ -277,28 +277,76 @@ class Query(ExportableSocialProtectionQueryMixin, graphene.ObjectType):
         return gql_optimizer.query(query, info)
 
     def resolve_group_beneficiary(self, info, **kwargs):
-        filters = append_validity_filter(**kwargs)
+        def _build_filters(info, **kwargs):
+            filters = append_validity_filter(**kwargs)
 
-        client_mutation_id = kwargs.get("client_mutation_id", None)
-        if client_mutation_id:
-            filters.append(Q(mutations__mutation__client_mutation_id=client_mutation_id))
+            client_mutation_id = kwargs.get("client_mutation_id")
+            if client_mutation_id:
+                filters.append(Q(mutations__mutation__client_mutation_id=client_mutation_id))
 
-        Query._check_permissions(
-            info.context.user,
-            SocialProtectionConfig.gql_beneficiary_search_perms
-        )
-        query = GroupBeneficiary.objects.filter(*filters)
+            Query._check_permissions(
+                info.context.user,
+                SocialProtectionConfig.gql_beneficiary_search_perms
+            )
+            return filters
 
-        custom_filters = kwargs.get("customFilters", None)
-        if custom_filters:
-            query = CustomFilterWizardStorage.build_custom_filters_queryset(
-                "individual",
-                "GroupIndividual",
-                custom_filters,
+        def _apply_custom_filters(query, **kwargs):
+            custom_filters = kwargs.get("customFilters")
+            if custom_filters:
+                query = CustomFilterWizardStorage.build_custom_filters_queryset(
+                    Query.module_name,
+                    Query.object_type,
+                    custom_filters,
+                    query,
+                    "group",
+                )
+            return query
+
+        def _get_eligible_group_uuids(query, info, **kwargs):
+            status = kwargs.get("status")
+            benefit_plan_id = kwargs.get("benefit_plan__id")
+            default_results = (set(), False)  # No eligibility check was performed
+
+            if not status or not benefit_plan_id:
+                return default_results
+
+            benefit_plan = BenefitPlan.objects.filter(id=benefit_plan_id).first()
+            if not benefit_plan:
+                return default_results
+
+            eligibility_filters = (benefit_plan.json_ext or {}).get('advanced_criteria', {}).get(status)
+            if not eligibility_filters:
+                return default_results
+
+            query_eligible = CustomFilterWizardStorage.build_custom_filters_queryset(
+                Query.module_name,
+                Query.object_type,
+                eligibility_filters,
                 query,
                 "group",
             )
+            eligible_group_beneficiaries = gql_optimizer.query(query_eligible, info)
+            eligible_group_uuids = set(eligible_group_beneficiaries.values_list('uuid', flat=True))
+            return eligible_group_uuids, True  # Eligibility check was performed
+
+        def _annotate_is_eligible(query, eligible_group_uuids, eligibility_check_performed):
+            return query.annotate(
+                is_eligible=Case(
+                    When(uuid__in=eligible_group_uuids, then=Value(True)),
+                    When(~Q(uuid__in=eligible_group_uuids) & Value(eligibility_check_performed), then=Value(False)),
+                    default=Value(None),
+                    output_field=BooleanField()
+                )
+            )
+
+        filters = _build_filters(info, **kwargs)
+        query = _apply_custom_filters(GroupBeneficiary.objects.filter(*filters), **kwargs)
+
+        eligible_group_uuids, eligibility_check_performed = _get_eligible_group_uuids(query, info, **kwargs)
+        query = _annotate_is_eligible(query, eligible_group_uuids, eligibility_check_performed)
+
         return gql_optimizer.query(query, info)
+
 
     def resolve_awaiting_beneficiary(self, info, **kwargs):
         filters = append_validity_filter(**kwargs)

--- a/social_protection/tests/group_beneficiary_gql_test.py
+++ b/social_protection/tests/group_beneficiary_gql_test.py
@@ -1,0 +1,230 @@
+from unittest import mock
+import graphene
+from core.models import User
+from core.models.openimis_graphql_test_case import openIMISGraphQLTestCase
+from core.test_helpers import create_test_interactive_user
+from social_protection import schema as sp_schema
+from graphene import Schema
+from graphene.test import Client
+from graphene_django.utils.testing import GraphQLTestCase
+from django.conf import settings
+from graphql_jwt.shortcuts import get_token
+from social_protection.tests.test_helpers import create_benefit_plan,\
+        create_group_with_individual, add_group_to_benefit_plan
+from social_protection.services import GroupBeneficiaryService
+import json
+
+class GroupBeneficiaryGQLTest(openIMISGraphQLTestCase):
+    schema = Schema(query=sp_schema.Query)
+
+    class BaseTestContext:
+        def __init__(self, user):
+            self.user = user
+
+    class AnonymousUserContext:
+        user = mock.Mock(is_anonymous=True)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = User.objects.filter(username='admin', i_user__isnull=False).first()
+        if not cls.user:
+            cls.user=create_test_interactive_user(username='admin')
+        cls.user_token = get_token(cls.user, cls.BaseTestContext(user=cls.user))
+        cls.benefit_plan = create_benefit_plan(cls.user.username, payload_override={
+            'code': 'GGQLTest',
+            'type': 'GROUP'
+        })
+        cls.individual_2child, cls.group_2child, _ = create_group_with_individual(cls.user.username)
+        cls.individual_1child, cls.group_1child, _ = create_group_with_individual(
+            cls.user.username,
+            individual_override={
+                'first_name': 'OneChild',
+                'json_ext': {
+                    'number_of_children': 1
+                }
+            }
+        )
+        cls.individual, cls.group_0child, _ =  create_group_with_individual(
+            cls.user.username,
+            individual_override={
+                'first_name': 'NoChild',
+                'json_ext': {
+                    'number_of_children': 0
+                }
+            }
+        )
+        cls.individual_not_enrolled, cls.group_not_enrolled, _ =  create_group_with_individual(
+            cls.user.username,
+            individual_override={
+                'first_name': 'Not enrolled',
+                'json_ext': {
+                    'number_of_children': 0,
+                    'able_bodied': True
+                }
+            }
+        )
+        cls.service = GroupBeneficiaryService(cls.user)
+        add_group_to_benefit_plan(cls.service, cls.group_2child, cls.benefit_plan)
+        add_group_to_benefit_plan(cls.service, cls.group_1child, cls.benefit_plan)
+        add_group_to_benefit_plan(cls.service, cls.group_0child, cls.benefit_plan,
+                                  payload_override={'status': 'ACTIVE'})
+
+    def test_query_beneficiary_basic(self):
+        response = self.query(
+            f"""
+            query {{
+              groupBeneficiary(benefitPlan_Id: "{self.benefit_plan.uuid}", isDeleted: false, first: 10) {{
+                totalCount
+                pageInfo {{
+                  hasNextPage
+                  hasPreviousPage
+                  startCursor
+                  endCursor
+                }}
+                edges {{
+                  node {{
+                    id
+                    jsonExt
+                    benefitPlan {{
+                      id
+                    }}
+                    group {{
+                      id
+                      code
+                    }}
+                    status
+                  }}
+                }}
+              }}
+            }}
+            """
+        , headers={"HTTP_AUTHORIZATION": f"Bearer {self.user_token}"})
+        self.assertResponseNoErrors(response)
+        response_data = json.loads(response.content)
+
+        # Asserting the response has one beneficiary record
+        beneficiary_data = response_data['data']['groupBeneficiary']
+        self.assertEqual(beneficiary_data['totalCount'], 3)
+
+        enrolled_group_codes = list(
+            e['node']['group']['code'] for e in beneficiary_data['edges']
+        )
+        self.assertTrue(self.group_0child.code in enrolled_group_codes)
+        self.assertTrue(self.group_1child.code in enrolled_group_codes)
+        self.assertTrue(self.group_2child.code in enrolled_group_codes)
+        self.assertFalse(self.group_not_enrolled.code in enrolled_group_codes)
+
+
+    def test_query_beneficiary_custom_filter(self):
+        query_str = f"""
+            query {{
+              groupBeneficiary(
+                benefitPlan_Id: "{self.benefit_plan.uuid}",
+                customFilters: ["number_of_children__lt__integer=2"],
+                isDeleted: false,
+                first: 10
+              ) {{
+                totalCount
+                pageInfo {{
+                  hasNextPage
+                  hasPreviousPage
+                  startCursor
+                  endCursor
+                }}
+                edges {{
+                  node {{
+                    id
+                    jsonExt
+                    benefitPlan {{
+                      id
+                    }}
+                    group {{
+                      id
+                      code
+                    }}
+                    status
+                  }}
+                }}
+              }}
+            }}
+        """
+        response = self.query(query_str,
+                              headers={"HTTP_AUTHORIZATION": f"Bearer {self.user_token}"})
+        self.assertResponseNoErrors(response)
+        response_data = json.loads(response.content)
+
+        beneficiary_data = response_data['data']['groupBeneficiary']
+        self.assertEqual(beneficiary_data['totalCount'], 2)
+
+        returned_group_codes = list(
+            e['node']['group']['code'] for e in beneficiary_data['edges']
+        )
+        self.assertTrue(self.group_0child.code in returned_group_codes)
+        self.assertTrue(self.group_1child.code in returned_group_codes)
+        self.assertFalse(self.group_2child.code in returned_group_codes)
+
+        query_str = query_str.replace('__lt__', '__gte__')
+
+        response = self.query(query_str,
+                              headers={"HTTP_AUTHORIZATION": f"Bearer {self.user_token}"})
+        self.assertResponseNoErrors(response)
+        response_data = json.loads(response.content)
+
+        beneficiary_data = response_data['data']['groupBeneficiary']
+        self.assertEqual(beneficiary_data['totalCount'], 1)
+
+        beneficiary_node = beneficiary_data['edges'][0]['node']
+        group_data = beneficiary_node['group']
+        self.assertEqual(group_data['code'], self.group_2child.code)
+
+
+    def test_query_beneficiary_status_filter(self):
+        query_str = f"""
+            query {{
+              groupBeneficiary(
+                benefitPlan_Id: "{self.benefit_plan.uuid}",
+                status: POTENTIAL,
+                isDeleted: false,
+                first: 10
+              ) {{
+                totalCount
+                pageInfo {{
+                  hasNextPage
+                  hasPreviousPage
+                  startCursor
+                  endCursor
+                }}
+                edges {{
+                  node {{
+                    id
+                    jsonExt
+                    benefitPlan {{
+                      id
+                    }}
+                    group {{
+                      id
+                      code
+                    }}
+                    status
+                  }}
+                }}
+              }}
+            }}
+        """
+        response = self.query(query_str,
+                              headers={"HTTP_AUTHORIZATION": f"Bearer {self.user_token}"})
+        self.assertResponseNoErrors(response)
+        response_data = json.loads(response.content)
+
+        beneficiary_data = response_data['data']['groupBeneficiary']
+        self.assertEqual(beneficiary_data['totalCount'], 2)
+
+        enrolled_group_codes = list(
+            e['node']['group']['code'] for e in beneficiary_data['edges']
+        )
+        self.assertFalse(self.group_0child.code in enrolled_group_codes)
+        self.assertTrue(self.group_1child.code in enrolled_group_codes)
+        self.assertTrue(self.group_2child.code in enrolled_group_codes)
+        self.assertFalse(self.group_not_enrolled.code in enrolled_group_codes)
+

--- a/social_protection/tests/group_beneficiary_gql_test.py
+++ b/social_protection/tests/group_beneficiary_gql_test.py
@@ -94,6 +94,7 @@ class GroupBeneficiaryGQLTest(openIMISGraphQLTestCase):
                       code
                     }}
                     status
+                    isEligible
                   }}
                 }}
               }}
@@ -114,6 +115,12 @@ class GroupBeneficiaryGQLTest(openIMISGraphQLTestCase):
         self.assertTrue(self.group_1child.code in enrolled_group_codes)
         self.assertTrue(self.group_2child.code in enrolled_group_codes)
         self.assertFalse(self.group_not_enrolled.code in enrolled_group_codes)
+
+        # eligibility is status specific, so None is expected for all records without status filter
+        eligible_none = list(
+            e['node']['isEligible'] is None for e in beneficiary_data['edges']
+        )
+        self.assertTrue(all(eligible_none))
 
 
     def test_query_beneficiary_custom_filter(self):
@@ -207,6 +214,7 @@ class GroupBeneficiaryGQLTest(openIMISGraphQLTestCase):
                       code
                     }}
                     status
+                    isEligible
                   }}
                 }}
               }}
@@ -228,3 +236,14 @@ class GroupBeneficiaryGQLTest(openIMISGraphQLTestCase):
         self.assertTrue(self.group_2child.code in enrolled_group_codes)
         self.assertFalse(self.group_not_enrolled.code in enrolled_group_codes)
 
+        def find_beneficiary_by_code(code):
+            for edge in beneficiary_data['edges']:
+                if edge['node']['group']['code'] == code:
+                    return edge['node']
+            return None
+
+        beneficiary_1child = find_beneficiary_by_code(self.group_1child.code)
+        self.assertFalse(beneficiary_1child['isEligible'])
+
+        beneficiary_2child = find_beneficiary_by_code(self.group_2child.code)
+        self.assertTrue(beneficiary_2child['isEligible'])

--- a/social_protection/tests/group_beneficiary_gql_test.py
+++ b/social_protection/tests/group_beneficiary_gql_test.py
@@ -26,10 +26,10 @@ class GroupBeneficiaryGQLTest(openIMISGraphQLTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super().setUpClass()
+        super(GroupBeneficiaryGQLTest, cls).setUpClass()
         cls.user = User.objects.filter(username='admin', i_user__isnull=False).first()
         if not cls.user:
-            cls.user=create_test_interactive_user(username='admin')
+            cls.user = create_test_interactive_user(username='admin')
         cls.user_token = get_token(cls.user, cls.BaseTestContext(user=cls.user))
         cls.benefit_plan = create_benefit_plan(cls.user.username, payload_override={
             'code': 'GGQLTest',

--- a/social_protection/tests/group_beneficiary_service_test.py
+++ b/social_protection/tests/group_beneficiary_service_test.py
@@ -10,7 +10,9 @@ from social_protection.tests.data import (
     service_beneficiary_add_payload, service_beneficiary_update_payload,
 )
 from core.test_helpers import LogInHelper
-from social_protection.tests.test_helpers import create_benefit_plan
+from social_protection.tests.test_helpers import (
+    create_benefit_plan, create_group
+)
 from datetime import datetime
 
 
@@ -29,7 +31,7 @@ class GroupBeneficiaryServiceTest(TestCase):
         cls.benefit_plan = create_benefit_plan(cls.user.username, payload_override={
             'type': "GROUP"
         })
-        cls.group = cls.__create_group(object_data={'code': str(datetime.now())})
+        cls.group = create_group(cls.user.username)
         cls.payload = {
             **service_beneficiary_add_payload,
             "group_id": cls.group.id,
@@ -66,11 +68,3 @@ class GroupBeneficiaryServiceTest(TestCase):
         self.assertTrue(result.get('success', False), result.get('detail', "No details provided"))
         query = self.query_all.filter(uuid=uuid)
         self.assertEqual(query.count(), 0)
-
-    @classmethod
-    def __create_group(cls, object_data={}):
-        
-        group = Group(**object_data)
-        group.save(username=cls.user.username)
-
-        return group

--- a/social_protection/tests/test_helpers.py
+++ b/social_protection/tests/test_helpers.py
@@ -1,11 +1,18 @@
+import random
+import string
 import copy
-from individual.models import Individual
+from individual.models import Individual, Group, GroupIndividual
 from social_protection.models import BenefitPlan
 from social_protection.tests.data import (
     service_add_payload_valid_schema,
     service_beneficiary_add_payload,
     service_add_individual_payload_with_ext,
 )
+
+
+def generate_random_string(length=6):
+    letters = string.ascii_uppercase
+    return ''.join(random.choice(letters) for i in range(length))
 
 def merge_dicts(original, override):
     updated = copy.deepcopy(original)
@@ -30,6 +37,29 @@ def create_individual(username, payload_override={}):
 
     return individual
 
+def create_group(username, payload_override={}):
+    updated_payload = merge_dicts({'code': generate_random_string()}, payload_override)
+    group = Group(**updated_payload)
+    group.save(username=username)
+    return group
+
+def add_individual_to_group(username, individual, group, is_head=True):
+    object_data = {
+        "individual_id": individual.id,
+        "group_id": group.id,
+    }
+    if is_head:
+        object_data["role"] = "HEAD"
+    group_individual = GroupIndividual(**object_data)
+    group_individual.save(username=username)
+    return group_individual
+
+def create_group_with_individual(username, group_override={}, individual_override={}):
+    individual = create_individual(username, individual_override)
+    group = create_group(username, group_override)
+    group_individual = add_individual_to_group(username, individual, group)
+    return individual, group, group_individual
+
 def add_individual_to_benefit_plan(service, individual, benefit_plan, payload_override={}):
     payload = {
         **service_beneficiary_add_payload,
@@ -38,6 +68,20 @@ def add_individual_to_benefit_plan(service, individual, benefit_plan, payload_ov
         "json_ext": individual.json_ext,
     }
     benefit_plan.type = BenefitPlan.BenefitPlanType.INDIVIDUAL_TYPE
+    updated_payload = merge_dicts(payload, payload_override)
+    result = service.create(updated_payload)
+    assert result.get('success', False), result.get('detail', "No details provided")
+    uuid = result.get('data', {}).get('uuid', None)
+    return uuid
+
+def add_group_to_benefit_plan(service, group, benefit_plan, payload_override={}):
+    payload = {
+        **service_beneficiary_add_payload,
+        "group_id": group.id,
+        "benefit_plan_id": benefit_plan.id,
+        "json_ext": group.json_ext,
+    }
+    benefit_plan.type = BenefitPlan.BenefitPlanType.GROUP_TYPE
     updated_payload = merge_dicts(payload, payload_override)
     result = service.create(updated_payload)
     assert result.get('success', False), result.get('detail', "No details provided")


### PR DESCRIPTION
Follow-up PR for #91, which adds the same functionalities but for group beneficiaries. Added graphql tests to guard existing filters and return fields as well as the newly added isEligible field and filter. @sniedzielski @delcroip kindly review.