### PR TITLE
Use core module’s module config registry to manage config reload

### DIFF
--- a/social_protection/apps.py
+++ b/social_protection/apps.py
@@ -2,10 +2,10 @@ import logging
 import json
 
 from django.apps import AppConfig
-from django.db.models.signals import post_save
 
 from core.custom_filters import CustomFilterRegistryPoint
 from core.data_masking import MaskingClassRegistryPoint
+from core.module_config_registry import register_reloader
 
 logger = logging.getLogger(__name__)
 
@@ -132,27 +132,18 @@ class SocialProtectionConfig(AppConfig):
         self.__load_config(cfg)
         self._set_up_workflows()
         self.__register_masking_class()
-        self.__connect_signals()
+        register_reloader(self.name, self._reload_module_config)
 
-    def __connect_signals(self):
-        from core.models import ModuleConfiguration
-        post_save.connect(
-            self._reload_module_config,
-            sender=ModuleConfiguration,
-            weak=False
-        )
+    def _reload_module_config(self, instance):
+        db_config = json.loads(instance.config)
+        config = {**DEFAULT_CONFIG, **db_config}
+        self.__load_config(config)
 
-    def _reload_module_config(self, sender, instance, **kwargs):
-        if instance.module == self.name and instance.layer == 'be':
-            db_config = json.loads(instance.config)
-            config = {**DEFAULT_CONFIG, **db_config}
-            self.__load_config(config)
+        # Workflow needs to be re-registered, otherwise default/invalid ones would apply
+        self._set_up_workflows()
 
-            # Workflow needs to be re-registered, otherwise default/invalid ones would apply
-            self._set_up_workflows()
-
-            # TODO: handle reloading of masking configs
-            logger.info(f"Reloaded app configs (except masking configs) for {self.name} module")
+        # TODO: handle reloading of masking configs
+        logger.info(f"Reloaded app configs (except masking configs) for {self.name} module")
 
     def _set_up_workflows(self):
         from workflow.systems.python import PythonWorkflowAdaptor

--- a/social_protection/tests/test_module_config.py
+++ b/social_protection/tests/test_module_config.py
@@ -13,7 +13,8 @@ class ModuleConfigTest(TestCase):
             config = ModuleConfiguration(module='social_protection', layer='be', config='{}')
         else:
             config.config = '{}'
-        config.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            config.save()
 
         self.assertTrue(SocialProtectionConfig.gql_check_benefit_plan_update)
         self.assertTrue(SocialProtectionConfig.enable_maker_checker_logic_enrollment)
@@ -24,7 +25,8 @@ class ModuleConfigTest(TestCase):
             "enable_maker_checker_logic_enrollment": False,
         }
         config.config = json.dumps(updated_config)
-        config.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            config.save()
 
         self.assertFalse(SocialProtectionConfig.gql_check_benefit_plan_update)
         self.assertFalse(SocialProtectionConfig.enable_maker_checker_logic_enrollment)

--- a/social_protection/tests/test_module_config.py
+++ b/social_protection/tests/test_module_config.py
@@ -7,9 +7,9 @@ from social_protection.apps import SocialProtectionConfig
 class ModuleConfigTest(TestCase):
 
     def test_config_reloading(self):
-        # First set the individual config to be empty
-        config = ModuleConfiguration.objects.filter(module='social_protection', layer='be')
-        if not config:
+        # First set the social_protection config to be empty
+        config = ModuleConfiguration.objects.filter(module='social_protection', layer='be').first()
+        if config is None:
             config = ModuleConfiguration(module='social_protection', layer='be', config='{}')
         else:
             config.config = '{}'


### PR DESCRIPTION
# Description

Use module config registry to handle reload, similar to https://github.com/openimis/openimis-be-individual_py/pull/170

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [x] Requires https://github.com/openimis/openimis-be-core_py/pull/426
- [x] Relates to https://github.com/openimis/openimis-be-individual_py/pull/170, https://github.com/openimis/openimis-be-grievance_social_protection_py/pull/38
- [ ] External reference (e.g., Jira):

## Demo

NA

## Checklist
- [x] Unit tests added/modified
- [ ] I18n / translation handled
